### PR TITLE
Check for existence of IntersectionObserver before using it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Compatibility
 * Ember.js v3.8 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
+* [All N-1 Browsers except IE](https://caniuse.com/#feat=intersectionobserver)
 
 
 Installation

--- a/addon/modifiers/did-intersect.js
+++ b/addon/modifiers/did-intersect.js
@@ -9,15 +9,19 @@ export default class DidIntersectModifier extends Modifier {
   observer = null;
 
   observe() {
-    this.observer = new IntersectionObserver((entries) => {
-      this.handler(entries[0]);
-    }, { threshold: this.threshold });
+    if ('IntersectionObserver' in window) {
+      this.observer = new IntersectionObserver((entries) => {
+        this.handler(entries[0]);
+      }, {threshold: this.threshold});
 
-    this.observer.observe(this.element);
+      this.observer.observe(this.element);
+    }
   }
 
   unobserve() {
-    this.observer.disconnect();
+    if (this.observer) {
+      this.observer.disconnect();
+    }
   }
 
   didUpdateArguments() {


### PR DESCRIPTION
This will suppress errors in unsupported browsers and make the `did-intersect` modifier a no-op. Along with current and improved documentation that tells developers which browsers are supported, this is a conscious choice to not throw an error where we KNOW there is no support for this feature.