### PR TITLE
Change to willRemove to ensure compatibility with ember-modifier 1.x

### DIFF
--- a/addon/modifiers/did-intersect.js
+++ b/addon/modifiers/did-intersect.js
@@ -25,6 +25,7 @@ export default class DidIntersectModifier extends Modifier {
     if (!this._isObservable) {
       return;
     }
+
     this.observerManager.unobserve(this.element, this._options);
   }
 
@@ -55,7 +56,8 @@ export default class DidIntersectModifier extends Modifier {
     this.observe();
   }
 
-  willDestroy() {
+  // Move to willDestroy when we want to drop support for versions below ember-modifier 2.x
+  willRemove() {
     this.unobserve();
   }
 }


### PR DESCRIPTION
Backporting willDestroy to willRemove to ensure this.element still exist for supporting. ember-modifier 1.x

The element is only accessible in the willDestroy, not the willRemove hook in ember-modifier 2.x. Anyone not on ember-modifier 2.x will see errors and memory leaks because calling `this._unobserve` can't find `this.element` inside the `willDestroy` hook.

Also added an if check to provide failures if the element doesn't exist, so the above is mostly for addressing potential memory leak.
