### PR TITLE
Adding addon-test-support to ember-scroll-modifiers

### DIFF
--- a/addon-test-support/did-intersect-mock.js
+++ b/addon-test-support/did-intersect-mock.js
@@ -1,0 +1,125 @@
+import { assert } from '@ember/debug';
+import { tracked } from '@glimmer/tracking';
+import { settled } from '@ember/test-helpers';
+import Modifier from 'ember-modifier';
+
+/**
+ * A mock class for did-intersect.
+ * Allows consumer to test their integration by explicitly invoking the callbacks deterministically.
+ * Provides 2 API:
+ * 1. enter() - to force trigger enter callback.
+ * 2. exit() - to force trigger exit callback.
+ *
+ * Uses `settled` to handle downstream side effects and to be consistent with other built-in test helpers.
+ *
+ * @example
+ * Integration Test
+ * ```js
+ *  const didIntersectMock = setupDidIntersectModifier(this);
+ *
+ *  await render(...);
+ *  ...
+ *
+ *  didIntersectMock.enter();
+ *  ...
+ *
+ *  didIntersectMock.exit();
+ * ```
+ */
+class DidIntersectMock {
+  onEnter;
+
+  onExit;
+
+  _numOfEnters = 0;
+
+  _numOfExits = 0;
+
+  maxEnterIntersections;
+
+  maxExitIntersections;
+
+  get _isExceedingMaxEnters() {
+    if (!Number.isInteger(this.maxEnterIntersections)) {
+      return false;
+    }
+
+    return this._numOfEnters >= this.maxEnterIntersections;
+  }
+
+  get _isExceedingMaxExits() {
+    if (!Number.isInteger(this.maxExitIntersections)) {
+      return false;
+    }
+
+    return this._numOfExits >= this.maxExitIntersections;
+  }
+
+  async enter() {
+    if (this._isExceedingMaxEnters) {
+      return settled();
+    }
+
+    this.onEnter();
+    this._numOfEnters++;
+
+    return settled();
+  }
+
+  async exit() {
+    if (this._isExceedingMaxExits) {
+      return settled();
+    }
+
+    this.onExit();
+    this._numOfExits++;
+
+    return settled();
+  }
+}
+
+/**
+ * Allows consummer to replace the real did-intersect with a did-intersect mock for deterministic testing.
+ * @param {Object} context the test context
+ */
+export function setupDidIntersectModifier(context) {
+  const didIntersectMock = new DidIntersectMock();
+
+  /**
+   * A dummy modifier to pass argumments into DidIntersectMock
+   */
+  class DidIntersectModifierMock extends Modifier {
+    didReceiveArguments() {
+      // Ignoring `options` because irrelevant for testing
+      let { onEnter, onExit, maxEnter, maxExit } = this.args.named;
+
+      assert('onEnter or/and onExit is required', onEnter || onExit);
+
+      if (onEnter) {
+        assert('onEnter must be a function', typeof onEnter === 'function');
+        didIntersectMock.onEnter = onEnter;
+      }
+
+      if (onExit) {
+        assert('onExit must be a function', typeof onExit === 'function');
+        didIntersectMock.onExit = onExit;
+      }
+
+      // We should technically accept 0, in case of programmatic changes
+      if (maxEnter || maxEnter === 0) {
+        assert('maxEnter must be an integer', Number.isInteger(maxEnter));
+        didIntersectMock.maxEnterIntersections = maxEnter;
+      }
+
+      // We should accept 0 here too.
+      if (maxExit || maxExit === 0) {
+        assert('maxExit must be an integer', Number.isInteger(maxExit));
+        didIntersectMock.maxExitIntersections = maxExit;
+      }
+    }
+  }
+
+  context.owner.register('modifier:did-intersect', DidIntersectModifierMock);
+
+  return didIntersectMock;
+}

--- a/addon-test-support/did-intersect-mock.js
+++ b/addon-test-support/did-intersect-mock.js
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { tracked } from '@glimmer/tracking';
 import { settled } from '@ember/test-helpers';
 import Modifier from 'ember-modifier';
 

--- a/tests/integration/modifiers/did-intersect-mock-test.js
+++ b/tests/integration/modifiers/did-intersect-mock-test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import { setupDidIntersectModifier } from 'ember-scroll-modifiers/test-support/did-intersect-mock';
+
+module(
+  'Integration | Modifier | addon-test-support/did-intersect-mock',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.didIntersectMock = setupDidIntersectModifier(this);
+      this.enterStub = sinon.stub();
+      this.exitStub = sinon.stub();
+      this.maxEnter = 1;
+      this.maxExit = 1;
+    });
+
+    test('Did intersect mock triggers onEnter correctly', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+      await this.didIntersectMock.enter();
+
+      assert.ok(this.enterStub.calledOnce);
+      assert.notOk(this.exitStub.calledOnce);
+    });
+
+    test('Did intersect mock triggers onExit correctly', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+      await this.didIntersectMock.exit();
+
+      assert.notOk(this.enterStub.calledOnce);
+      assert.ok(this.exitStub.calledOnce);
+    });
+
+    test('Did intersect mock triggers onExit never exceeds maxEnter if maxEnter is provided', async function (assert) {
+      assert.expect(1);
+
+      await render(
+        hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub maxEnter=this.maxEnter}}></div>`
+      );
+
+      for (let i = 0; i < this.maxEnter + 1; i++) {
+        await this.didIntersectMock.enter();
+      }
+
+      assert.equal(this.enterStub.callCount, this.maxEnter);
+    });
+
+    test('Did intersect mock triggers onExit never exceeds maxExit if maxExit is provided', async function (assert) {
+      assert.expect(1);
+
+      await render(
+        hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub maxExit=this.maxExit}}></div>`
+      );
+
+      for (let i = 0; i < this.maxExit + 1; i++) {
+        await this.didIntersectMock.exit();
+      }
+
+      assert.equal(this.exitStub.callCount, this.maxExit);
+    });
+
+    test('Did intersect mock fire without limit if maxEnter and maxExit is not provided', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+
+      const numOfFiredCallback = this.maxEnter + this.maxExit;
+
+      for (let i = 0; i < numOfFiredCallback; i++) {
+        this.didIntersectMock.enter();
+        this.didIntersectMock.exit();
+      }
+
+      assert.equal(
+        this.enterStub.callCount,
+        numOfFiredCallback,
+        'Enter callback has fired more than maxEnter times'
+      );
+      assert.equal(
+        this.exitStub.callCount,
+        numOfFiredCallback,
+        'Exit callback has fired more than maxExit times'
+      );
+    });
+  }
+);


### PR DESCRIPTION
This new helper will support most of the API that the consumer should care about, `onEnter`, `onExit`, `maxEnter`, and `maxExit`.

**Description**
- [x] Adds a new `addon-test-support` helper, `did-intersect-mock`
- [x] Added a few integration tests for `did-intersect-mock` to make sure it'll work.
- [ ] Documentation, will add after initial review looks good.

**API**
 - [x] enter - mimics `onEnter`, but since it is directly invokable, `enter` sounds more semantic.
 - [x] exit - mimics `onExit`, name follows same reason.