### PR TITLE
Introduce addon-test-support by mocking IntersectionObserver

### DIFF
--- a/addon-test-support/did-intersect-mock.js
+++ b/addon-test-support/did-intersect-mock.js
@@ -38,7 +38,7 @@ class MockIntersectionObserver {
 
   /**
    * Force a single element to enter the viewport
-   * @param {DomElement} el
+   * @param {String} el - a DOM selector string
    */
   static enter(el) {
     return MockIntersectionObserver.forceElement(find(el), {
@@ -49,13 +49,12 @@ class MockIntersectionObserver {
 
   /**
    * Force a single element to exit the viewport
-   * @param {DomElement} el
+   * @param {DomElement} el - a DOM Selector string
    */
   static exit(el) {
     return MockIntersectionObserver.forceElement(find(el), {
       isIntersecting: false,
       intersectionRatio: 0,
-      // time: 100,
     });
   }
 

--- a/addon-test-support/did-intersect-mock.js
+++ b/addon-test-support/did-intersect-mock.js
@@ -1,0 +1,93 @@
+import { A as emberArray } from '@ember/array';
+import { settled, find } from '@ember/test-helpers';
+
+/**
+ * This replaces the browser's IntersectionObserver with a mocked one that is synchronous
+ * as opposed to asynchronous, and controllable by us.
+ *
+ * forceElement return `settled()` for convenience, so that
+ * any downstream side-effects can be awaited. This is also done for consistency with
+ * the rest of our test helpers.
+ *
+ * Usage:
+ *
+ * const didIntersectMock = mockDidIntersect(sinon);
+ * ...render logic...
+ * await didIntersectMock.enter();
+ */
+class MockIntersectionObserver {
+  static instances = [];
+
+  constructor(callback) {
+    this.callback = callback;
+    this._watchedElements = emberArray();
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element) {
+    this._watchedElements.addObject(element);
+  }
+
+  unobserve(element) {
+    this._watchedElements.removeObject(element);
+  }
+
+  disconnect() {
+    this._watchedElements = [];
+  }
+
+  /**
+   * Force a single element to enter the viewport
+   * @param {DomElement} el
+   */
+  static enter(el) {
+    return MockIntersectionObserver.forceElement(find(el), {
+      isIntersecting: true,
+      intersectionRatio: 1,
+    });
+  }
+
+  /**
+   * Force a single element to exit the viewport
+   * @param {DomElement} el
+   */
+  static exit(el) {
+    return MockIntersectionObserver.forceElement(find(el), {
+      isIntersecting: false,
+      intersectionRatio: 0,
+      // time: 100,
+    });
+  }
+
+  /**
+   * Force an IntersectionObserverEntry targetted at a specific DOM node.
+   * Useful when only triggering viewport state on certain elements.
+   *
+   * @param {DomElement} el
+   * @param {object} [state] Additional state to be passed as the IntersectionObserverEntry
+   */
+  static forceElement(el, state) {
+    MockIntersectionObserver.instances.forEach((instance) => {
+      if (instance._watchedElements.includes(el)) {
+        instance.callback([
+          {
+            target: el,
+            ...state,
+          },
+        ]);
+      }
+    });
+    return settled();
+  }
+}
+
+/**
+ * Replaces the global IntersectionObserver with the MockIntersectionObserver class
+ *
+ * @param {Sinon} sinon Pass sinon as the argument to ensure the mock is undone at the end of the test
+ */
+export default function mockDidIntersect(sinon) {
+  sinon.replace(MockIntersectionObserver, 'instances', []);
+  sinon.replace(window, 'IntersectionObserver', MockIntersectionObserver);
+  return MockIntersectionObserver;
+}

--- a/addon-test-support/did-intersect-mock.js
+++ b/addon-test-support/did-intersect-mock.js
@@ -60,7 +60,7 @@ class MockIntersectionObserver {
   }
 
   /**
-   * Force an IntersectionObserverEntry targetted at a specific DOM node.
+   * Force an IntersectionObserverEntry targeted at a specific DOM node.
    * Useful when only triggering viewport state on certain elements.
    *
    * @param {DomElement} el

--- a/tests/dummy/app/templates/docs/did-intersect.md
+++ b/tests/dummy/app/templates/docs/did-intersect.md
@@ -44,7 +44,7 @@ You can also set a maximum limit on the number of times the callbacks should tri
 The options supported are documented in the MDN site under [Intersection observer options](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#Intersection_observer_options).
 
 ## Testing
-Since the underlying IntersectionObserver behavior is non-deterministic, we provid a `did-intersect-mock` test helper to help you test `did-intersect` deterministically.
+Since the underlying IntersectionObserver behavior is non-deterministic, we provide a `did-intersect-mock` test helper to help you test `did-intersect` deterministically.
 
 `did-intersect-mock` creates a mock provides 2 APIs
 

--- a/tests/dummy/app/templates/docs/did-intersect.md
+++ b/tests/dummy/app/templates/docs/did-intersect.md
@@ -43,6 +43,42 @@ You can also set a maximum limit on the number of times the callbacks should tri
 
 The options supported are documented in the MDN site under [Intersection observer options](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#Intersection_observer_options).
 
+## Testing
+Since the underlying IntersectionObserver behavior is non-deterministic, we provid a `did-intersect-mock` test helper to help you test `did-intersect` deterministically.
+
+`did-intersect-mock` creates a mock provides 2 APIs
+
+1. `enter(elementString)` triggers the `onEnter` callback, given an DOM element string
+2. `exit(elementString)` triggers the `onExit` callback, given an DOM element string
+
+```javascript
+import mockDidIntersect from 'ember-scroll-modifiers/test-support/did-intersect-mock';
+
+...
+const didIntersectMock = mockDidIntersect(sinon);
+
+await render(hbs`
+  <div
+    data-test-did-intersect
+    {{did-intersect onEnter=this.onEnteringIntersection onExit=this.onExitingIntersection}}
+  >
+  </div>
+`)
+...
+await didIntersectMock.enter('[data-test-did-intersect]');
+...
+await didIntersectMock.exit('[data-test-did-intersect]');
+```
+
+Even though, this effectively allows you to trigger the `did-intersect` on demand without requiring real app interactions, you should still do it as best practice.
+
+```javascript
+...
+await triggerEvent('scroll');
+await didIntersectMock.enter('[data-test-did-intersect]');
+...
+```
+
 ## Browser Support
 
 This feature is [supported](https://caniuse.com/#search=intersectionobserver) in the latest versions of every browser except IE 11.

--- a/tests/integration/modifiers/did-intersect-mock-test.js
+++ b/tests/integration/modifiers/did-intersect-mock-test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import mockDidIntersect from 'ember-scroll-modifiers/test-support/did-intersect-mock';
+
+module(
+  'Integration | Modifier | addon-test-support/did-intersect-mock',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.didIntersectMock = mockDidIntersect(sinon);
+      this.enterStub = sinon.stub();
+      this.exitStub = sinon.stub();
+      this.maxEnter = 1;
+      this.maxExit = 1;
+    });
+
+    test('Did intersect mock triggers onEnter correctly', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div data-test-did-intersect {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+      await this.didIntersectMock.enter('[data-test-did-intersect]');
+
+      assert.ok(this.enterStub.calledOnce);
+      assert.notOk(this.exitStub.calledOnce);
+    });
+
+    test('Did intersect mock triggers onExit correctly', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div data-test-did-intersect {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+      await this.didIntersectMock.exit('[data-test-did-intersect]');
+
+      assert.notOk(this.enterStub.calledOnce);
+      assert.ok(this.exitStub.calledOnce);
+    });
+
+    test('Did intersect mock triggers onExit never exceeds maxEnter if maxEnter is provided', async function (assert) {
+      assert.expect(1);
+
+      await render(
+        hbs`<div data-test-did-intersect {{did-intersect onEnter=this.enterStub onExit=this.exitStub maxEnter=this.maxEnter}}></div>`
+      );
+
+      for (let i = 0; i < this.maxEnter + 1; i++) {
+        await this.didIntersectMock.enter('[data-test-did-intersect]');
+      }
+
+      assert.equal(this.enterStub.callCount, this.maxEnter);
+    });
+
+    test('Did intersect mock triggers onExit never exceeds maxExit if maxExit is provided', async function (assert) {
+      assert.expect(1);
+
+      await render(
+        hbs`<div data-test-did-intersect {{did-intersect onEnter=this.enterStub onExit=this.exitStub maxExit=this.maxExit}}></div>`
+      );
+
+      for (let i = 0; i < this.maxExit + 1; i++) {
+        await this.didIntersectMock.exit('[data-test-did-intersect]');
+      }
+
+      assert.equal(this.exitStub.callCount, this.maxExit);
+    });
+
+    test('Did intersect mock fire without limit if maxEnter and maxExit is not provided', async function (assert) {
+      assert.expect(2);
+
+      await render(
+        hbs`<div data-test-did-intersect {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}></div>`
+      );
+
+      const numOfFiredCallback = this.maxEnter + this.maxExit;
+
+      for (let i = 0; i < numOfFiredCallback; i++) {
+        this.didIntersectMock.enter('[data-test-did-intersect]');
+        this.didIntersectMock.exit('[data-test-did-intersect]');
+      }
+
+      assert.equal(
+        this.enterStub.callCount,
+        numOfFiredCallback,
+        'Enter callback has fired more than maxEnter times'
+      );
+      assert.equal(
+        this.exitStub.callCount,
+        numOfFiredCallback,
+        'Exit callback has fired more than maxExit times'
+      );
+    });
+  }
+);


### PR DESCRIPTION
This new helper will support most of the API that the consumer should care about, `onEnter`, `onExit`, `maxEnter`, and `maxExit`.

**Description**
- [x] Adds a new `addon-test-support` helper, `did-intersect-mock`
- [x] Added a few integration tests for `did-intersect-mock` to make sure it'll work.
- [x] Documentation, will add after initial review looks good.

**API**
 - [x] enter - mimics `onEnter`, but since it is directly invokable, `enter` sounds more semantic.
 - [x] exit - mimics `onExit`, name follows same reason.
 
 `IntersectionObserver` implementation credit goes to @seanjohnson08. Made some small modifications.