### PR TITLE
Update did-intersect.md

### DIFF
--- a/tests/dummy/app/templates/docs/did-intersect.md
+++ b/tests/dummy/app/templates/docs/did-intersect.md
@@ -74,7 +74,7 @@ Even though, this effectively allows you to trigger the `did-intersect` on deman
 
 ```javascript
 ...
-await triggerEvent('scroll');
+await triggerEvent('[data-test-root-element-selector]', 'scroll');
 await didIntersectMock.enter('[data-test-did-intersect]');
 ...
 ```


### PR DESCRIPTION
triggerevent expects first parameter to be an element, second one is the event. Small update to the reading me to reflect that.
https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent