### PR TITLE
Allow programmatic control of observation

### DIFF
--- a/addon/modifiers/did-intersect.js
+++ b/addon/modifiers/did-intersect.js
@@ -77,7 +77,14 @@ export default class DidIntersectModifier extends Modifier {
       return;
     }
 
-    let { onEnter, onExit, maxEnter, maxExit, options } = this.args.named;
+    let {
+      onEnter,
+      onExit,
+      maxEnter,
+      maxExit,
+      options,
+      isObserving = true,
+    } = this.args.named;
 
     assert('onEnter or/and onExit is required', onEnter || onExit);
 
@@ -161,7 +168,11 @@ export default class DidIntersectModifier extends Modifier {
       this._options = options;
     }
 
-    this.observe();
+    if (isObserving) {
+      this.observe();
+    } else {
+      this.unobserve();
+    }
   }
 
   // Move to willDestroy when we want to drop support for versions below ember-modifier 2.x

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -12,6 +12,12 @@ export default class IndexController extends Controller {
   maxIntersections = 5;
 
   @tracked
+  isObserving = true;
+
+  @tracked
+  numIntersectionsWithIsObserving = 0;
+
+  @tracked
   shouldScrollIntoView = false;
 
   @action
@@ -22,6 +28,16 @@ export default class IndexController extends Controller {
   @action
   onEnteringIntersectionWithMaxEnter() {
     this.numIntersectionsWithMaxEnter++;
+  }
+
+  @action
+  toggleIsObserving() {
+    this.isObserving = !this.isObserving;
+  }
+
+  @action
+  onEnteringWithIsObserving() {
+    this.numIntersectionsWithIsObserving++;
   }
 
   @action

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -9,17 +9,17 @@
   }
 }
 
+.action-button {
+  border-radius: 4px;
+  padding: 0.5em;
+  background-color: orangered;
+  color: white;
+}
+
 .scroll-into-view {
   border: 1px dotted black;
   padding: 50px 16px;
   text-align: center;
-
-  button {
-    border-radius: 4px;
-    padding: .5em;
-    background-color: orangered;
-    color: white;
-  }
 }
 
 // prevent copy button from overlapping code

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -24,12 +24,31 @@
     </demo.example>
     {{demo.snippet "did-intersect-with-max-enter.hbs" label="example with max enter.hbs"}}
 
+    <demo.example @name="did-intersect-with-is-observing.hbs">
+      <div
+        class="intersection-box"
+        {{did-intersect
+          isObserving=this.isObserving
+          onEnter=this.onEnteringWithIsObserving
+        }}
+      >
+        <p>Number of times this box has intersected the screen: {{this.numIntersectionsWithIsObserving}}</p>
+
+        <p>isObserving: {{this.isObserving}}</p>
+
+        <button type='button' class="action-button" {{on "click" this.toggleIsObserving}}>
+          {{if this.isObserving "Stop" "Start"}} observing
+        </button>
+      </div>
+    </demo.example>
+    {{demo.snippet "did-intersect-with-is-observing.hbs" label="example with isObserving.hbs"}}
+
     <demo.example @name="scroll-into-view.hbs">
       <div
         class="scroll-into-view"
         {{scroll-into-view shouldScroll=this.shouldScrollIntoView}}
       >
-        <button type="button" class="scroll-into-view__button" {{on "click" this.onScrollIntoViewTrigger}}>
+        <button type="button" class="action-button" {{on "click" this.onScrollIntoViewTrigger}}>
           Trigger Scroll-into-view on click
         </button>
       </div>


### PR DESCRIPTION
Add a named new argument, `isObserving`, with a default value of `true`, which users can pass to explicitly opt into or out of observing an element at a given time. This allows for a declarative invocation of the modifier itself based on tracked state, rather than having to handle it in the callback(s) passed to the modifier.

Users can work around this today by only passing the `onEnter` or `onExit` callbacks conditionally:

```hbs
<div
  {{did-intersect
    onEnter=(if this.shouldDoSomething this.doSomething no-op)
    onExist=(if this.shouldDoSomething this.doSomethingElse no-op)
  }}
>
```

However, as this example shows, this is repetive (and potentially error- prone). The new functionality allows a less error-prone, less repetitive, more expressive approach:

```hbs
<div
  {{did-intersect
    isObserving=this.shouldDoSomething
    onEnter=this.doSomething
    onExit=this.doSomethingElse
  }}
>
```

Resolves #396