### PR TITLE
Fix Fastboot Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "sass": "^1.56.1",
     "webpack": "^5.75.0"
   },
+  "fastbootDependencies": [ "crypto" ],
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },


### PR DESCRIPTION
Ember-Data has an opaque dependency on the `crypto` package, which causes FastBoot to fail when booting up the field-guide documentation app. This adds `crypto` to `fastbootDependencies` to allow our docs to boot properly.

More info: https://github.com/emberjs/data/issues/8101