### PR TITLE
Allow `ember-source` v5 in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "crypto"
   ],
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Fixes #850

cc @elwayman02