### PR TITLE
DRAFT: feat(memory-leak): add elements cleanup for did-intersect modifier

### DIFF
--- a/addon/modifiers/did-intersect.js
+++ b/addon/modifiers/did-intersect.js
@@ -8,6 +8,11 @@ export const DEFAULT_OBSERVER_OPTIONS = {};
 
 function cleanup(instance) {
   instance.unobserve.call(instance);
+  instance.observerManager.removeElement(instance.element);
+  instance.observerManager.removeElement(window);
+  instance.onEnter = null;
+  instance.onExit = null;
+  instance.element = null;
 }
 
 export default class DidIntersectModifier extends Modifier {

--- a/addon/services/observer-manager.js
+++ b/addon/services/observer-manager.js
@@ -23,4 +23,9 @@ export default class ObserverManagerService extends Service {
   willDestroy() {
     this._admin.destroy();
   }
+
+  removeElement(element) {
+    this._admin.elementRegistry.removeElement(element);
+    this._admin.registry.removeElement(element);
+  }
 }

--- a/tests/integration/modifiers/real-did-intersect-test.js
+++ b/tests/integration/modifiers/real-did-intersect-test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+module(
+  'Integration | Modifier | did-intersect without mocks',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.enterStub = sinon.stub();
+      this.exitStub = sinon.stub();
+      this.maxEnter = 1;
+      this.maxExit = 1;
+
+      this.observerManagerService = this.owner.lookup(
+        'service:ember-scroll-modifiers@observer-manager',
+      );
+    });
+
+    test('it removes elements from the registry on modifier cleanup', async function (assert) {
+      let removedElementsCount = 0;
+      let originalRemoveElement = this.observerManagerService.removeElement;
+      const observerManagerService = this.observerManagerService;
+
+      observerManagerService.removeElement = function removeElementExt(
+        ...args
+      ) {
+        removedElementsCount++;
+        originalRemoveElement.call(observerManagerService, ...args);
+      };
+      for (let index = 0; index < 50; index++) {
+        await render(
+          hbs`<div {{did-intersect onEnter=this.enterStub onExit=this.exitStub}}>
+          <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
+        </div>`,
+        );
+      }
+
+      assert.strictEqual(
+        removedElementsCount,
+        49 * 2, // once for the element, once for a window object
+      );
+    });
+  },
+);


### PR DESCRIPTION
Our client has been experiencing severe memory leaks. Which `did-intersect` was partially responsible for.
Currently I'm in the process of porting our monkey patches and documenting the issue.
We've also found `ember-in-viewport` to be causing these, which in turn is using `intersection-observer-admin` just like this addon.

Applying an identical fixes to both addons has fixed our problems.

With fix:
![image](https://github.com/elwayman02/ember-scroll-modifiers/assets/15948633/2db402b2-2a0a-4eff-9a07-186ab0f38d9a)

Without fix:
![image](https://github.com/elwayman02/ember-scroll-modifiers/assets/15948633/b5fbce50-1d49-4699-9282-3e24e6682772)
