### PR TITLE
Remove use of `inject`

### DIFF
--- a/addon/modifiers/did-intersect.js
+++ b/addon/modifiers/did-intersect.js
@@ -1,6 +1,6 @@
 import Modifier from 'ember-modifier';
 import { registerDestructor } from '@ember/destroyable';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 


### PR DESCRIPTION
`inject` is now deprecated:
https://deprecations.emberjs.com/v6.x#toc_importing-inject-from-ember-service