### PR TITLE
Add a fastboot config for `field-guide` > 3.0.1

### DIFF
--- a/demo-app/config/fastboot.js
+++ b/demo-app/config/fastboot.js
@@ -1,0 +1,30 @@
+/*
+ * Fastboot runs in a "sandbox" that is by default unaware of Node globals.
+ * Globals used in the demo-app built with field-guide (typically fetch) must
+ * be passed to the sandbox explicitly. Aside from fetch, the content of this
+ * file is rather generic to Ember and EmberData.
+ */
+module.exports = function () {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return Object.assign({}, defaultGlobals, {
+        atob: atob,
+        fetch: fetch,
+        AbortController,
+        ReadableStream:
+          typeof ReadableStream !== 'undefined'
+            ? ReadableStream
+            : require('node:stream/web').ReadableStream,
+        WritableStream:
+          typeof WritableStream !== 'undefined'
+            ? WritableStream
+            : require('node:stream/web').WritableStream,
+        TransformStream:
+          typeof TransformStream !== 'undefined'
+            ? TransformStream
+            : require('node:stream/web').TransformStream,
+        Headers: typeof Headers !== 'undefined' ? Headers : undefined,
+      });
+    },
+  };
+};


### PR DESCRIPTION
PR #1225 introduced a bug in the demo app by upgrading the version of _field-guide_ that was enforced.

**History**: When _field-guide_ was updated to version `3.0.0` in #1273, the exact version `3.0.0` was enforced by removing `^` because the patch [`3.0.1`](https://github.com/empress/field-guide/releases/tag/v3.0.1-field-guide) was introducing an error related to the `fetch` definition that was not a priority to investigate at that time. #1225 introduced the bug by upgrading to 3.1.0, greater than 3.0.1.

This PR addresses the root cause of the issue, allowing us to keep _field-guide_ 3.1.0 installed.

The meaning of the 3.0.1 patch is that `fetch` is now available in Node by default; it's part of the globals, so we no longer need a tool like `ember-fetch` to define the method. However, the way Fastboot works is peculiar, and the Node globals are not available by default when serving an app with Fastboot. Globals need to be passed explicitly to the Fastboot sandbox, which can be done through a configuration file _fastboot.js_.